### PR TITLE
fix: Support for line comments in Vue scripts

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -32,7 +32,7 @@ function formatContent (source, isSFC) {
         const res = compiler.parseComponent(source, { pad: 'line' });
         return {
             template: res.template.content.replace(/{{/g, '{').replace(/}}/g, '}'),
-            js: res.script.content.replace(/\/\//g, '')
+            js: res.script.content
         };
     } else {
         return {


### PR DESCRIPTION
Scripts were having their line comment token removed '//'. This is not necessary, and caused comments to break. This has been reverted.